### PR TITLE
parse integer from string before converting to integer

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -59,7 +59,7 @@ module Openssh
     end
 
     def rhel_7_plus?
-      platform_family?('rhel') && node['platform_version'].to_i >= 7
+      platform_family?('rhel') && node['platform_version'].split(/\./)[0].to_i >= 7
     end
 
     def opensuse_15_plus?


### PR DESCRIPTION
Signed-off-by: Mike S <mikeysky@gmail.com>

# Description

Fixes integer comparison on CentOS 8.3.2011 so /usr/libexec/openssh/sshd-keygen is run instead of /usr/sbin/sshd-keygen.

## Issues Resolved

Resolves #139 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
