### PR TITLE
Fix Match orderings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the openssh cookbook.
 
 ## Unreleased
 
+- Improved sorting of Match objects in sshd_config
+
 ## 2.9.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This means anything located in [sshd_config](http://www.openbsd.org/cgi-bin/man.
 - `Hash` attributes are meant to used with `ssh_config` namespace to create host-specific configurations. The keys of the `Hash` will be used as the `Host` entries and their associated entries as the configuration values.
 - All the values in openssh are commented out in the `attributes/default.rb` file for a base starting point.
 - There is one special attribute name, which is `match`. This is not included in the default template like the others. `node['openssh']['server']['match']` must be a Hash, where the key is the match pattern criteria and the value should be a Hash of normal keywords and values. The same transformations listed above apply to these keywords. See examples below.
+    - To get improved sorting of match items, you can prefix the key with a number.  See examples below.
 
 ## Dynamic ListenAddress
 
@@ -105,6 +106,23 @@ This requires use of identity files to connect
       "Group admins": {
         "permit_tunnel": "yes",
         "max_sessions": "20"
+      }
+    }
+  }
+}
+```
+
+### Match with sorting
+
+```json
+"openssh": {
+  "server": {
+    "match": {
+      "0 User foobar": {
+        "force_command": "internal-sftp -d /home/%u -l VERBOSE"
+      },
+      "Group admins": {
+        "force_command": "internal-sftp -d /home/admins -l VERBOSE"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ This means anything located in [sshd_config](http://www.openbsd.org/cgi-bin/man.
 - If it is an `Array`, each item in the array will get it's own line in the config file.
 - `Hash` attributes are meant to used with `ssh_config` namespace to create host-specific configurations. The keys of the `Hash` will be used as the `Host` entries and their associated entries as the configuration values.
 - All the values in openssh are commented out in the `attributes/default.rb` file for a base starting point.
-- There is one special attribute name, which is `match`. This is not included in the default template like the others. `node['openssh']['server']['match']` must be a Hash, where the key is the match pattern criteria and the value should be a Hash of normal keywords and values. The same transformations listed above apply to these keywords. See examples below.
-    - To get improved sorting of match items, you can prefix the key with a number.  See examples below.
+- There is one special attribute name, which is `match`. This is not included in the default template like the others. `node['openssh']['server']['match']` must be a Hash, where the key is the match pattern criteria and the value should be a Hash of normal keywords and values. The same transformations listed above apply to these keywords. To get improved sorting of match items, you can prefix the key with a number.  See examples below.
 
 ## Dynamic ListenAddress
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -25,15 +25,11 @@ platforms:
     driver:
       image: dokken/debian-9
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: centos-7
     driver:
@@ -64,17 +60,13 @@ platforms:
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -26,8 +26,8 @@ Subsystem <%= node['openssh']['server']['subsystem'] %>
 <%  end -%>
 
 <%  unless node['openssh']['server']['match'].empty? || !defined?(node['openssh']['server']['match']) -%>
-<%    node['openssh']['server']['match'].map do |match_key, match_items| -%>
-Match <%= match_key %>
+<%    node['openssh']['server']['match'].sort.map do |match_key, match_items| -%>
+Match <%= match_key.sub(/^[0-9]+/, '').strip %>
 <%      match_items.sort.map do |key, value| -%>
 <%        if value.kind_of? Array -%>
 <%          value.each do |item| -%>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -26,7 +26,7 @@ Subsystem <%= node['openssh']['server']['subsystem'] %>
 <%  end -%>
 
 <%  unless node['openssh']['server']['match'].empty? || !defined?(node['openssh']['server']['match']) -%>
-<%    node['openssh']['server']['match'].sort.map do |match_key, match_items| -%>
+<%    node['openssh']['server']['match'].map do |match_key, match_items| -%>
 Match <%= match_key %>
 <%      match_items.sort.map do |key, value| -%>
 <%        if value.kind_of? Array -%>


### PR DESCRIPTION
Signed-off-by: Matthew M mjmjelde@gmail.com

# Description

This removes the sorting applied to the match objects in sshd_config.  The ordering of these objects are important as it defines the order of which certain rules are applied to users.  By having the sort in the template, the ordering specified by the attributes can get removed.

## Issues Resolved

Not aware of any issues it resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
