### PR TITLE
fix sshd-keygen command location for amz linux 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the openssh cookbook.
 
 ## Unreleased
 
+- fix sshd-keygen command location for Amazon Linux 2023
+
 ## 2.11.6 - *2023-12-21*
 
 ## 2.11.5 - *2023-09-29*

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,12 +60,12 @@ end
 # this will only execute on RHEL / Fedora systems where sshd has never been started
 # 99.99% of the time this is going to be a docker container
 if keygen_platform? && sshd_host_keys_missing?
-  if platform_family?('fedora', 'rhel') && node['platform_version'].to_i >= 8 # fedora and RHEL 8+
+  if platform_family?('fedora', 'rhel', 'amazon') && node['platform_version'].to_i >= 8 # fedora, RHEL 8+, Amazonlinux 2023+
     node['openssh']['server']['host_key'].each do |key|
       keytype = key.split('_')[-2]
       execute "/usr/libexec/openssh/sshd-keygen #{keytype}"
     end
-  elsif platform_family?('rhel', 'amazon') # RHEL < 8 or Amazon Linux
+  elsif platform_family?('rhel', 'amazon') # RHEL < 8 or Amazon Linux 2
     execute '/usr/sbin/sshd-keygen'
   elsif platform_family?('suse')
     execute '/usr/sbin/sshd-gen-keys-start'


### PR DESCRIPTION
# Description

fixes the sshd-keygen command location for amazon linux 2023

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
