### PR TITLE
Ensure Match blocks are 'closed'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the openssh cookbook.
 
 ## Unreleased
 
+- In more recent enterprise linux (rhel, oel, etc) systems system policies are added at end of sshd config and therefor any match block needs to be closed
+
 ## 2.11.14 - *2024-11-18*
 
 Standardise files with files in sous-chefs/repo-management

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -38,4 +38,5 @@ Match <%= match_key.sub(/^[0-9]+/, '').strip %>
 <%        end -%>
 <%      end -%>
 <%    end -%>
+Match all
 <%  end -%>


### PR DESCRIPTION
# Description

In recent enterprise linux systems the system security policies are appended at the end of "sshd_config".
If we do not 'close' the match block it will be interpreted in the level of the match block.
This fix will ensure it is in the right context.

## Issues Resolved

N/A

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
